### PR TITLE
CNN proxy parsing fixes

### DIFF
--- a/js/surf.js
+++ b/js/surf.js
@@ -81,10 +81,10 @@ document.getElementById("cnn").onclick = function cnn() {
   var url = $("url").value;
   //this is the URL for the server
   is_url(url);
-  var urlSUB1 = url.replace("-", "_-");
-  var urlSUB = urlSUB1.replace(".", "--");
-  var nerd2 = urlSUB.replace("https://", "");
-  var nerd1 = urlSUB.replace("http://", "");
+  var urlSUB1 = url.replaceAll("-", "_-");
+  var urlSUB = urlSUB1.replaceAll(".", "--");
+  var nerd2 = urlSUB.replaceAll("https://", "");
+  var nerd1 = urlSUB.replaceAll("http://", "");
   var n = url.includes("https://");
   var y = url.includes("http://");
   if (n) {


### PR DESCRIPTION
fixed an issue where when you use the CNN proxy with a URL that has multiple '.' or '-' it does not parse correctly